### PR TITLE
Missing character in the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Then, in Chrome:
     - go to **Tools / Extensions**,
     - expand **Developer mode**,
     - click **Load unpacked extension**,
-    - select the .resurrection folder.
+    - select the ./resurrection folder.
 
 Usage
 =====


### PR DESCRIPTION
Therefore, there could have been some confusion over where to find the folder. I know it's nothing, but well, just in case...
