### PR TITLE
Replace function does not replace all occurences

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -376,7 +376,7 @@ TestRecorder.ElementInfo.prototype.getCleanCSSSelector = function(element) {
         if(accuracy==1) return selector;
     }
     if(element.className) {
-        tmp_selector = '.' + element.className.replace(' ', '.');
+        tmp_selector = '.' + element.className.trim().replace(/ /g,".");
         if(document.querySelectorAll(tmp_selector).length < accuracy) {
             selector = tmp_selector;
             accuracy = document.querySelectorAll(selector).length


### PR DESCRIPTION
Replace function did not replace all classes, script failed on clicking dom items with more then 2 classes.
This adds replace with a regex replace with a global flag to replace all occurrences, as well as trimming it so cases lik class="   btn" won't break the code
