### PR TITLE
possible fix for escaping of quotes around string

### DIFF
--- a/casper.js
+++ b/casper.js
@@ -63,8 +63,10 @@ CasperRenderer.prototype.pyout = function(text) {
 
 CasperRenderer.prototype.pyrepr = function(text, escape) {
   // todo: handle non--strings & quoting
-  var s =  "'" + text + "'";
-  if(escape) s = s.replace(/(['"])/g, "\\$1");
+  // There should a more eloquent way of doing this but by  doing the escaping before adding the string quotes prevents the string quotes from accidentally getting escaped creating a syntax error in the output code.
+	var s = text;
+	if (escape) s = s.replace(/(['"])/g, "\\$1");
+	var s = "'" + s + "'"; 
   return s;
 }
 


### PR DESCRIPTION
There should a more eloquent way of doing this but by  doing the escaping before adding the string quotes prevents the string quotes from accidentally getting escaped creating a syntax error in the output code.
