### PR TITLE
Fix for when a form contains a input called "name"

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -309,7 +309,7 @@ TestRecorder.ElementInfo = function(element) {
     if (this.type)
         this.type = this.type.toLowerCase();
     if (element.form)
-        this.form = {id: element.form.id, name: element.form.name};
+        this.form = {id: element.form.id, name: element.form.getAttribute('name')};
     this.src = element.src;
     this.id = element.id;
     this.title = element.title;


### PR DESCRIPTION
When a form contains a input called name calling `name` on the form will return that input element, not the forms name. This results in a selector like `form[name=[object Object]]` when later stringified. The fix is to call getAttribute() instead of accessing the property directly.

Tested on Chrome 59.0.3071.109.